### PR TITLE
Fix layers regexp and OrientationField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ coverage.xml
 .coverage
 doc/build
 .tox
+.venv
+venv
+build
+.idea

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -74,6 +74,10 @@ Improvements
 - normal and volume transmission pipelines now share the source node file
 - All the fibers and their information (start point, direction) are now included in the output nodes file
 
+Bug Fixes
+~~~~~~~~~
+- Fix layers regexp to match acronyms in the latest hierarchy.
+- Do not convert OrientationField to int8, as it can contain float data.
 
 Version v2.0.2
 --------------

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "luigi>3.0",
         "matplotlib<4.0.0",
         "morphio<4.0.0",
-        "numpy>=1.19",
+        "numpy>=1.19,<2",
         "pandas<2.0.0",
         "pyarrow>=0.11.1",
         "pyyaml<7.0",

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -20,7 +20,7 @@ phy = phy.transpose(1, 2, 0)
 ph6 = np.full((*phy.shape, 2), np.nan)
 br = np.zeros(phy.shape)
 
-# each layer has it's own region id [11,...,16]
+# each layer has its own region id [11,...,16]
 for i in range(6):
     ind = 51 - i*10
     br[1:-1, ind:ind+10, 1:-1] = 11+i

--- a/tests/data/hierarchy.json
+++ b/tests/data/hierarchy.json
@@ -1,41 +1,117 @@
 {
-  "id" : 65535,
-  "acronym" : "Br",
-  "name" : "brain",
-  "children" : [{
-    "id" : 5,
-    "acronym" : "TEST",
-    "name" : "fake cortex",
-    "children" : [{
-        "id" : 10,
-        "acronym" : "TEST_layers",
-        "name" : "test region",
-        "children" : [ {
-          "id" : 11,
-          "acronym" : "L1",
-          "name" : "test_layer_1"
-        }, {
-          "id" : 12,
-          "acronym" : "L2",
-          "name" : "test_layer_2"
-        }, {
-          "id" : 13,
-          "acronym" : "L3",
-          "name" : "test_layer_3"
-        }, {
-          "id" : 14,
-          "acronym" : "L4",
-          "name" : "test_layer_4"
-        }, {
-          "id" : 15,
-          "acronym" : "L5",
-          "name" : "test_layer_5"
-        }, {
-          "id" : 16,
-          "acronym" : "L6",
-          "name" : "test_layer_6"
-        } ]
-      }
-    ]
-  }]
+  "id": 65535,
+  "acronym": "Br",
+  "name": "brain",
+  "children": [
+    {
+      "id": 5,
+      "acronym": "TEST",
+      "name": "fake cortex",
+      "children": [
+        {
+          "id": 10,
+          "acronym": "TEST_layers",
+          "name": "test region",
+          "children": [
+            {
+              "id": 11,
+              "acronym": "TEST1",
+              "name": "test_layer_1"
+            },
+            {
+              "id": 12,
+              "acronym": "TEST2",
+              "name": "test_layer_2"
+            },
+            {
+              "id": 13,
+              "acronym": "TEST3",
+              "name": "test_layer_3"
+            },
+            {
+              "id": 14,
+              "acronym": "TEST4",
+              "name": "test_layer_4"
+            },
+            {
+              "id": 15,
+              "acronym": "TEST5",
+              "name": "test_layer_5"
+            },
+            {
+              "id": 16,
+              "acronym": "TEST6a",
+              "name": "test_layer_6a"
+            },
+            {
+              "id": 17,
+              "acronym": "TEST6b",
+              "name": "test_layer_6b"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "acronym": "TEST-ALT",
+      "name": "fake alt cortex",
+      "children": [
+        {
+          "id": 20,
+          "acronym": "SSp-bfd",
+          "name": "SSp-bfd region",
+          "children": [
+            {
+              "id": 21,
+              "acronym": "SSp-bfd1",
+              "name": "SSp-bfd layer 1"
+            },
+            {
+              "id": 22,
+              "acronym": "SSp-bfd2",
+              "name": "SSp-bfd layer 2"
+            },
+            {
+              "id": 23,
+              "acronym": "SSp-bfd2/3",
+              "name": "SSp-bfd layer 2/3"
+            },
+            {
+              "id": 24,
+              "acronym": "SSp-bfd3",
+              "name": "SSp-bfd layer 3"
+            }
+          ]
+        },
+        {
+          "id": 30,
+          "acronym": "SSp-bfd-A1",
+          "name": "SSp-bfd-A1 region",
+          "children": [
+            {
+              "id": 31,
+              "acronym": "SSp-bfd-A1-1",
+              "name": "SSp-bfd-A1 layer 1"
+            },
+            {
+              "id": 32,
+              "acronym": "SSp-bfd-A1-2",
+              "name": "SSp-bfd-A1 layer 2"
+            },
+            {
+              "id": 33,
+              "acronym": "SSp-bfd-A1-2/3",
+              "name": "SSp-bfd-A1 layer 2/3"
+            },
+            {
+              "id": 34,
+              "acronym": "SSp-bfd-A1-3",
+              "name": "SSp-bfd-A1 layer 3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tests/test_sscx.py
+++ b/tests/test_sscx.py
@@ -109,6 +109,6 @@ def test_recipe_to_relative_heights_per_layer():
 
     ret = test_module.recipe_to_relative_heights_per_layer(distance, atlas, layers)
 
-    assert_array_equal(np.isfinite(ret.raw), atlas.get_region_mask("L6", attr="acronym").raw)
+    assert_array_equal(np.isfinite(ret.raw), atlas.get_region_mask("TEST6a", attr="acronym").raw)
     assert np.all(ret.raw[np.isfinite(ret.raw)] >= 0.0)
     assert np.all(ret.raw[np.isfinite(ret.raw)] <= 1.0)

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv=
     BRAIN_INDEXER_CACHE_SIZE_MB=666
 
 deps = {[base]testdeps}
-commands = pytest tests
+commands = pytest -v tests
 
 [testenv:check-version]
 skip_install = true


### PR DESCRIPTION
- Fix layers regexp to match acronyms in the latest hierarchy.
- Do not convert OrientationField to int8, as it can contain float data.